### PR TITLE
Feat/track nfts by owner

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,7 @@ on:
   push:    
     branches:
       - main
+      - feat/track-nfts-by-owner
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/contracts/LidoNFT.sol
+++ b/contracts/LidoNFT.sol
@@ -155,6 +155,7 @@ contract LidoNFT is
         lido = _lido;
     }
 
+    /// @notice Retrieve owned tokens by address
     function getOwnedTokens(address _address)
         public
         view
@@ -163,6 +164,7 @@ contract LidoNFT is
         return owner2Tokens[_address];
     }
 
+    /// @notice Retrieve approved tokens by address
     function getApprovedTokens(address _address)
         public
         view

--- a/test/lido-nft-test.ts
+++ b/test/lido-nft-test.ts
@@ -1,0 +1,99 @@
+import { ethers, upgrades } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import { LidoNFT__factory, LidoNFT } from "../typechain";
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+
+describe("LidoNFT", () => {
+    let deployer: SignerWithAddress;
+    let accounts: SignerWithAddress[];
+    let lidoNFT: LidoNFT;
+
+    before(async () => {
+        [deployer, ...accounts] = await ethers.getSigners();
+
+        const LidoNft = (await ethers.getContractFactory(
+            "LidoNFT",
+            deployer
+        )) as LidoNFT__factory;
+
+        lidoNFT = (await upgrades.deployProxy(LidoNft, [
+            "stMATIC_NFT",
+            "STM_NFT"
+        ])) as LidoNFT;
+        await lidoNFT.deployed();
+
+        await lidoNFT.setLido(deployer.address);
+    });
+
+    describe("Testing main functionalities...", async () => {
+        it("should successfully mint 1 token to deployer, 2 tokens to account0, 3 tokens to account1 and 4 tokens to account3", async () => {
+            await lidoNFT.mint(deployer.address);
+            await lidoNFT.mint(accounts[0].address);
+            await lidoNFT.mint(accounts[0].address);
+            await lidoNFT.mint(accounts[1].address);
+            await lidoNFT.mint(accounts[1].address);
+            await lidoNFT.mint(accounts[1].address);
+            await lidoNFT.mint(accounts[2].address);
+            await lidoNFT.mint(accounts[2].address);
+            await lidoNFT.mint(accounts[2].address);
+            await lidoNFT.mint(accounts[2].address);
+
+            const deployerBalance = await lidoNFT.balanceOf(deployer.address);
+            const account0Balance = await lidoNFT.balanceOf(accounts[0].address);
+            const account1Balance = await lidoNFT.balanceOf(accounts[1].address);
+            const account2Balance = await lidoNFT.balanceOf(accounts[2].address);
+
+            const totalSupply = await lidoNFT.totalSupply();
+
+            expect(totalSupply.toNumber()).to.equal(10);
+            expect(deployerBalance.toNumber()).to.equal(1);
+            expect(account0Balance.toNumber()).to.equal(2);
+            expect(account1Balance.toNumber()).to.equal(3);
+            expect(account2Balance.toNumber()).to.equal(4);
+        });
+        it("Should successfully retrieve owned tokens of address", async () => {
+            const deployerTokens = await lidoNFT.getOwnedTokens(deployer.address);
+            const account0Tokens = await lidoNFT.getOwnedTokens(accounts[0].address);
+            const account1Tokens = await lidoNFT.getOwnedTokens(accounts[1].address);
+            const account2Tokens = await lidoNFT.getOwnedTokens(accounts[2].address);
+
+            const deployerExpected = [BigNumber.from(1)];
+            const account0Expected = [BigNumber.from(2), BigNumber.from(3)];
+            const account1Expected = [BigNumber.from(4), BigNumber.from(5), BigNumber.from(6)];
+            const account2Expected = [BigNumber.from(7), BigNumber.from(8), BigNumber.from(9), BigNumber.from(10)];
+
+            expect(deployerTokens).to.eql(deployerExpected);
+            expect(account0Tokens).to.eql(account0Expected);
+            expect(account1Tokens).to.eql(account1Expected);
+            expect(account2Tokens).to.eql(account2Expected);
+        });
+        it("Should successfully transfer token 2 from account0 to deployer and update owned tokens", async () => {
+            lidoNFT = lidoNFT.connect(accounts[0]);
+            await lidoNFT.approve(deployer.address, 2);
+
+            // Check if a token is in approval list
+            const deployerApprovedPre = await lidoNFT.getApprovedTokens(deployer.address);
+            const approvedExpectedPre = [BigNumber.from(2)];
+            expect(deployerApprovedPre).to.eql(approvedExpectedPre);
+
+            lidoNFT = lidoNFT.connect(deployer);
+            await lidoNFT.transferFrom(accounts[0].address, deployer.address, 2);
+
+            const deployerExpected = [BigNumber.from(1), BigNumber.from(2)];
+            const deployerTokens = await lidoNFT.getOwnedTokens(deployer.address);
+
+            const account0Expected = [BigNumber.from(3)];
+            // Remove all 0 entries
+            const account0Tokens = (await lidoNFT.getOwnedTokens(accounts[0].address)).filter(tokenId => tokenId.toNumber() !== 0);
+
+            expect(deployerTokens).to.eql(deployerExpected);
+            expect(account0Expected).to.eql(account0Tokens);
+
+            // Check if approval was reset
+            const deployerApprovedPost = (await lidoNFT.getApprovedTokens(deployer.address)).filter(tokenId => tokenId.toNumber() !== 0);
+            expect(deployerApprovedPost.length).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
- Added logic to LidoNFT to increase user experience on frontend
- User will be able to see his pending claims (tokenIds) by displaying concatenated arrays retrieved by calling getOwnedTokens(address _user) and getApprovedTokens(address _user)
- Added tests