### PR TITLE
Feat/get matic from polido nft

### DIFF
--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -875,4 +875,27 @@ contract StMATIC is
     {
         version = _version;
     }
+
+    /**
+     * @dev Function that retrieves the amount of matic that will be claimed from the NFT token
+     * @param _tokenId - Id of the PolidoNFT
+     */
+    function getMaticFromTokenId(uint256 _tokenId)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        RequestWithdraw memory requestData = token2WithdrawRequest[_tokenId];
+        IValidatorShare validatorShare = IValidatorShare(
+            requestData.validatorAddress
+        );
+        uint256 validatorId = validatorShare.validatorId();
+        uint256 exchangeRatePrecision = validatorId < 8 ? 100 : 10**29;
+        uint256 withdrawExchangeRate = validatorShare.withdrawExchangeRate();
+        IValidatorShare.DelegatorUnbond memory unbond = validatorShare
+            .unbonds_new(address(this), requestData.validatorNonce);
+
+        return (withdrawExchangeRate * unbond.shares) / exchangeRatePrecision;
+    }
 }

--- a/contracts/interfaces/IStMATIC.sol
+++ b/contracts/interfaces/IStMATIC.sol
@@ -39,6 +39,11 @@ interface IStMATIC is IERC20Upgradeable {
             uint8
         );
 
+    function getMaticFromTokenId(uint256 _tokenId)
+        external
+        view
+        returns (uint256);
+
     function stakeManager() external view returns (IStakeManager);
 
     function poLidoNFT() external view returns (IPoLidoNFT);

--- a/contracts/interfaces/IValidatorShare.sol
+++ b/contracts/interfaces/IValidatorShare.sol
@@ -3,11 +3,18 @@
 pragma solidity 0.8.7;
 
 interface IValidatorShare {
+    struct DelegatorUnbond {
+        uint256 shares;
+        uint256 withdrawEpoch;
+    }
+
     function unbondNonces(address _address) external view returns (uint256);
 
     function activeAmount() external view returns (uint256);
 
-    function validatorId() external returns (uint256);
+    function validatorId() external view returns (uint256);
+
+    function withdrawExchangeRate() external view returns (uint256);
 
     function withdrawRewards() external;
 
@@ -29,6 +36,11 @@ interface IValidatorShare {
         external;
 
     function unstakeClaimTokens_new(uint256 unbondNonce) external;
+
+    function unbonds_new(address _address, uint256 _unbondNonce)
+        external
+        view
+        returns (DelegatorUnbond memory);
 
     function getTotalStake(address user)
         external

--- a/contracts/mocks/ValidatorShareMock.sol
+++ b/contracts/mocks/ValidatorShareMock.sol
@@ -117,6 +117,15 @@ contract ValidatorShareMock is IValidatorShare {
         return (totalStaked, 1);
     }
 
+    function withdrawExchangeRate() external view override returns (uint256) {
+        return 0;
+    }
+
+    function unbonds_new(address _address, uint256 _unbondNonce) external view override returns (DelegatorUnbond memory) {
+        DelegatorUnbond memory unbond = DelegatorUnbond(1,2);
+        return unbond;
+    }
+
     function owner() external pure override returns (address) {
         return address(0);
     }

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -1200,8 +1200,7 @@ describe("NodeOperator", function () {
             it("Fail setStakeAmountAndFees", async function () {
                 const minAmountStake = BigNumber.from(10);
                 const minHeimdallFees = BigNumber.from(100);
-                await expect(getNodeOperatorState
-                    nodeOperatorRegistry
+                await expect(nodeOperatorRegistry
                         .connect(user1)
                         .setStakeAmountAndFees(minAmountStake, minHeimdallFees)
                 ).revertedWith("unauthorized");


### PR DESCRIPTION
A function that will convert the claimable amount in Matic from the PolidoNFT token id has been added. This is used on the frontend application for informing the user how much will they be able to claim at the time during the processing of their request for withdraw (https://github.com/Shard-Labs/PoLido/blob/feat/get-matic-from-polidoNFT/contracts/StMATIC.sol#L854). 