### PR TITLE
PR40 Audit Fix

### DIFF
--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -294,13 +294,9 @@ contract NodeOperatorRegistry is
         );
 
         checkCondition(
-            poValidator.status == IStakeManager.Status.Active,
+            (poValidator.status == IStakeManager.Status.Active
+                ) && poValidator.deactivationEpoch == 0 ,
             "Validator isn't ACTIVE"
-        );
-
-        checkCondition(
-            poValidator.deactivationEpoch != 0,
-            "Validator is UNSTAKED"
         );
 
         checkCondition(

--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -99,8 +99,6 @@ contract NodeOperatorRegistry is
     /// extend the struct.
     mapping(address => uint256) private operatorOwners;
 
-    /// @notice Mapping of all validatorShare with operatorId
-    mapping(address => uint256) private validatorShare2OperatorId;
 
     /// @notice Mapping of all node operators. Mapping is used to be able to extend the struct.
     mapping(uint256 => NodeOperator) private operators;
@@ -229,7 +227,10 @@ contract NodeOperatorRegistry is
     {
         (, NodeOperator storage no) = getOperator(_operatorId);
         NodeOperatorStatus status = getOperatorStatus(no);
-        checkCondition(status <= NodeOperatorStatus.ACTIVE, "Invalid status");
+        checkCondition(
+            status <= NodeOperatorStatus.ACTIVE ||
+            status == NodeOperatorStatus.JAILED
+        , "Invalid status");
 
         if (status == NodeOperatorStatus.INACTIVE) {
             no.status = NodeOperatorStatus.EXIT;
@@ -239,30 +240,6 @@ contract NodeOperatorRegistry is
         }
         no.statusUpdatedTimestamp = block.timestamp;
         emit StopOperator(_operatorId);
-    }
-
-    /// @notice Allows to switch an operator status from WAIT to EXIT.
-    /// this function should only be called by the StMatic contract inside claimTokens2StMatic.
-    function exitOperator(address _validatorShare) external override {
-        checkCondition(msg.sender == stMATIC, "Caller is not stMATIC contract");
-
-        (, NodeOperator storage no) = getOperator(
-            validatorShare2OperatorId[_validatorShare]
-        );
-        NodeOperatorStatus status = getOperatorStatus(no);
-
-        if (
-            status == NodeOperatorStatus.UNSTAKED ||
-            status == NodeOperatorStatus.CLAIMED
-        ) {
-            return;
-        }
-
-        checkCondition(status == NodeOperatorStatus.STOPPED, "Invalid status");
-        no.status = NodeOperatorStatus.WAIT;
-        no.statusUpdatedTimestamp = block.timestamp;
-
-        delete validatorShare2OperatorId[no.validatorShare];
     }
 
     /// @notice Allows to remove an operator from the system.when the operator status is
@@ -322,6 +299,11 @@ contract NodeOperatorRegistry is
         );
 
         checkCondition(
+            poValidator.deactivationEpoch != 0,
+            "Validator is UNSTAKED"
+        );
+
+        checkCondition(
             poValidator.signer ==
                 address(uint160(uint256(keccak256(no.signerPubkey)))),
             "Invalid Signer"
@@ -340,7 +322,6 @@ contract NodeOperatorRegistry is
 
         address validatorShare = sm.getValidatorContract(validatorId);
         no.validatorShare = validatorShare;
-        validatorShare2OperatorId[validatorShare] = operatorId;
 
         emit JoinOperator(operatorId);
     }
@@ -382,7 +363,6 @@ contract NodeOperatorRegistry is
         no.validatorId = validatorId;
         no.validatorShare = validatorShare;
         no.statusUpdatedTimestamp = block.timestamp;
-        validatorShare2OperatorId[validatorShare] = operatorId;
 
         emit StakeOperator(operatorId, _amount, _heimdallFee);
     }
@@ -463,7 +443,7 @@ contract NodeOperatorRegistry is
     /// This can be done only in the case where this operator was stopped by the DAO.
     function migrate() external override nonReentrant {
         (uint256 operatorId, NodeOperator storage no) = getOperator(0);
-        checkCondition(no.status == NodeOperatorStatus.WAIT, "Invalid status");
+        checkCondition(no.status == NodeOperatorStatus.STOPPED, "Invalid status");
         IValidator(no.validatorProxy).migrate(
             no.validatorId,
             IStakeManager(stakeManager).NFTContract(),
@@ -567,12 +547,7 @@ contract NodeOperatorRegistry is
             polygonERC20
         );
 
-        if (validatorShare2OperatorId[no.validatorShare] != 0) {
-            no.status = NodeOperatorStatus.EXIT;
-            delete validatorShare2OperatorId[no.validatorShare];
-        } else {
-            no.status = NodeOperatorStatus.WAIT;
-        }
+        no.status = NodeOperatorStatus.EXIT;
         no.statusUpdatedTimestamp = block.timestamp;
 
         emit ClaimFee(operatorId);
@@ -823,8 +798,6 @@ contract NodeOperatorRegistry is
     {
         if (_op.status == NodeOperatorStatus.STOPPED) {
             res = NodeOperatorStatus.STOPPED;
-        } else if (_op.status == NodeOperatorStatus.WAIT) {
-            res = NodeOperatorStatus.WAIT;
         } else if (_op.status == NodeOperatorStatus.CLAIMED) {
             res = NodeOperatorStatus.CLAIMED;
         } else if (_op.status == NodeOperatorStatus.EXIT) {

--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -157,7 +157,7 @@ contract StMATIC is
         require(_amount > 0, "Invalid amount");
 
         Operator.OperatorInfo[] memory operatorInfos = nodeOperatorRegistry
-            .getOperatorInfos(false, false, false);
+            .getOperatorInfos(false, false, true);
 
         uint256 operatorInfosLength = operatorInfos.length;
 
@@ -495,7 +495,6 @@ contract StMATIC is
             abi.encode(totalSupply(), getTotalPooledMatic())
         );
 
-        nodeOperatorRegistry.exitOperator(lidoRequests.validatorAddress);
         emit ClaimTokensEvent(address(this), _tokenId, claimedAmount, 0);
     }
 

--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -368,7 +368,7 @@ contract StMATIC is
      */
     function distributeRewards() external override whenNotPaused {
         Operator.OperatorInfo[] memory operatorInfos = nodeOperatorRegistry
-            .getOperatorInfos(true, false, false);
+            .getOperatorInfos(true, true, false);
 
         uint256 operatorInfosLength = operatorInfos.length;
 

--- a/contracts/Validator.sol
+++ b/contracts/Validator.sol
@@ -16,20 +16,20 @@ import "./interfaces/INodeOperatorRegistry.sol";
 /// @notice The validator contract is a simple implementation of the stakeManager API, the
 /// ValidatorProxies use this contract to interact with the stakeManager.
 /// When a ValidatorProxy calls this implementation the state is copied
-/// (owner, implementation, operator), then they are used to check if the msg-sender is the
+/// (owner, implementation, operatorRegistry), then they are used to check if the msg-sender is the
 /// node operator contract, and if the validatorProxy implementation match with the current
 /// validator contract.
 contract Validator is IERC721Receiver, IValidator {
     using SafeERC20 for IERC20;
 
     address private implementation;
-    address private operator;
+    address private operatorRegistry;
     address private validatorFactory;
 
     /// @notice Check if the operator contract is the msg.sender.
-    modifier isOperator() {
+    modifier isOperatorRegistry() {
         require(
-            msg.sender == operator,
+            msg.sender == operatorRegistry,
             "Caller should be the operator contract"
         );
         _;
@@ -54,7 +54,7 @@ contract Validator is IERC721Receiver, IValidator {
         uint256 _commissionRate,
         address _stakeManager,
         address _polygonERC20
-    ) external override isOperator returns (uint256, address) {
+    ) external override isOperatorRegistry returns (uint256, address) {
         IStakeManager stakeManager = IStakeManager(_stakeManager);
         IERC20 polygonERC20 = IERC20(_polygonERC20);
 
@@ -92,7 +92,7 @@ contract Validator is IERC721Receiver, IValidator {
         bool _stakeRewards,
         address _stakeManager,
         address _polygonERC20
-    ) external override isOperator {
+    ) external override isOperatorRegistry {
         if (_amount > 0) {
             IERC20 polygonERC20 = IERC20(_polygonERC20);
             polygonERC20.safeTransferFrom(_sender, address(this), _amount);
@@ -107,7 +107,7 @@ contract Validator is IERC721Receiver, IValidator {
     function unstake(uint256 _validatorId, address _stakeManager)
         external
         override
-        isOperator
+        isOperatorRegistry
     {
         // stakeManager
         IStakeManager(_stakeManager).unstake(_validatorId);
@@ -123,7 +123,7 @@ contract Validator is IERC721Receiver, IValidator {
         uint256 _heimdallFee,
         address _stakeManager,
         address _polygonERC20
-    ) external override isOperator {
+    ) external override isOperatorRegistry {
         IStakeManager stakeManager = IStakeManager(_stakeManager);
         IERC20 polygonERC20 = IERC20(_polygonERC20);
 
@@ -143,7 +143,7 @@ contract Validator is IERC721Receiver, IValidator {
         address _rewardAddress,
         address _stakeManager,
         address _polygonERC20
-    ) external override isOperator returns (uint256) {
+    ) external override isOperatorRegistry returns (uint256) {
         IStakeManager(_stakeManager).withdrawRewards(_validatorId);
 
         IERC20 polygonERC20 = IERC20(_polygonERC20);
@@ -164,7 +164,7 @@ contract Validator is IERC721Receiver, IValidator {
         address _rewardAddress,
         address _stakeManager,
         address _polygonERC20
-    ) external override isOperator returns (uint256) {
+    ) external override isOperatorRegistry returns (uint256) {
         IStakeManager stakeManager = IStakeManager(_stakeManager);
         stakeManager.unstakeClaim(_validatorId);
         // polygonERC20
@@ -184,7 +184,7 @@ contract Validator is IERC721Receiver, IValidator {
         uint256 _validatorId,
         bytes memory _signerPubkey,
         address _stakeManager
-    ) external override isOperator {
+    ) external override isOperatorRegistry {
         IStakeManager(_stakeManager).updateSigner(_validatorId, _signerPubkey);
     }
 
@@ -199,7 +199,7 @@ contract Validator is IERC721Receiver, IValidator {
         address _rewardAddress,
         address _stakeManager,
         address _polygonERC20
-    ) external override isOperator {
+    ) external override isOperatorRegistry {
         IStakeManager stakeManager = IStakeManager(_stakeManager);
         stakeManager.claimFee(_accumFeeAmount, _index, _proof);
 
@@ -216,7 +216,7 @@ contract Validator is IERC721Receiver, IValidator {
         uint256 _validatorId,
         uint256 _newCommissionRate,
         address _stakeManager
-    ) public override isOperator {
+    ) public override isOperatorRegistry {
         IStakeManager(_stakeManager).updateCommissionRate(
             _validatorId,
             _newCommissionRate
@@ -228,7 +228,7 @@ contract Validator is IERC721Receiver, IValidator {
     function unjail(uint256 _validatorId, address _stakeManager)
         external
         override
-        isOperator
+        isOperatorRegistry
     {
         IStakeManager(_stakeManager).unjail(_validatorId);
     }
@@ -241,7 +241,7 @@ contract Validator is IERC721Receiver, IValidator {
         uint256 _validatorId,
         address _stakeManagerNFT,
         address _rewardAddress
-    ) external override isOperator {
+    ) external override isOperatorRegistry {
         IERC721 erc721 = IERC721(_stakeManagerNFT);
         erc721.approve(_rewardAddress, _validatorId);
         erc721.safeTransferFrom(address(this), _rewardAddress, _validatorId);
@@ -260,7 +260,7 @@ contract Validator is IERC721Receiver, IValidator {
         address _rewardAddress,
         uint256 _newCommissionRate,
         address _stakeManager
-    ) external override isOperator {
+    ) external override isOperatorRegistry {
         IERC721 erc721 = IERC721(_stakeManagerNFT);
         erc721.safeTransferFrom(_rewardAddress, address(this), _validatorId);
         updateCommissionRate(_validatorId, _newCommissionRate, _stakeManager);

--- a/contracts/ValidatorFactory.sol
+++ b/contracts/ValidatorFactory.sol
@@ -18,13 +18,13 @@ contract ValidatorFactory is IValidatorFactory, OwnableUpgradeable {
     /// @notice the contract version.
     string public version;
     /// @notice the node operator address.
-    address public operator;
+    address public operatorRegistry;
     /// @notice the validator implementation address.
     address public validatorImplementation;
 
     /// @notice Check if the operator contract is the msg.sender.
-    modifier isOperator() {
-        require(operator == msg.sender, "Caller is not the operator contract");
+    modifier isOperatorRegistry() {
+        require(operatorRegistry == msg.sender, "Caller is not the operator contract");
         _;
     }
 
@@ -41,12 +41,12 @@ contract ValidatorFactory is IValidatorFactory, OwnableUpgradeable {
 
     /// @notice Deploy a new validator contract
     /// @return return the address of the new validator contract deployed
-    function create() external override isOperator returns (address) {
-        require(operator != address(0), "Operator contract not set");
+    function create() external override isOperatorRegistry returns (address) {
+        require(operatorRegistry != address(0), "Operator contract not set");
 
         // create a new validator proxy
         address proxy = address(
-            new ValidatorProxy(validatorImplementation, operator, address(this))
+            new ValidatorProxy(validatorImplementation, operatorRegistry, address(this))
         );
 
         validators.push(proxy);
@@ -56,7 +56,7 @@ contract ValidatorFactory is IValidatorFactory, OwnableUpgradeable {
 
     /// @notice Remove a validator proxy from the list.
     /// @param _validatorProxy validator proxy address.
-    function remove(address _validatorProxy) external override isOperator {
+    function remove(address _validatorProxy) external override isOperatorRegistry {
         require(
             _validatorProxy != address(0),
             "Could not remove a zero address"
@@ -76,7 +76,7 @@ contract ValidatorFactory is IValidatorFactory, OwnableUpgradeable {
     /// with the new address.
     /// @param _newOperator new operator address.
     function setOperator(address _newOperator) public override onlyOwner {
-        operator = _newOperator;
+        operatorRegistry = _newOperator;
 
         uint256 length = validators.length;
         for (uint256 idx = 0; idx < length; idx++) {

--- a/contracts/interfaces/INodeOperatorRegistry.sol
+++ b/contracts/interfaces/INodeOperatorRegistry.sol
@@ -160,8 +160,6 @@ interface INodeOperatorRegistry {
         view
         returns (Operator.OperatorInfo[] memory);
 
-    /// @notice Allows update an operator status from WAIT to EXIT
-    function exitOperator(address _validatorShare) external;
 
     /// @notice Allows to get all the operator ids.
     function getOperatorIds() external view returns (uint256[] memory);

--- a/contracts/mocks/StMATICMock.sol
+++ b/contracts/mocks/StMATICMock.sol
@@ -17,6 +17,5 @@ contract StMATICMock {
 
     function claimTokens2StMatic(address _validatorShare) public {
         require(operator != address(0), "Operator address not set");
-        INodeOperatorRegistry(operator).exitOperator(_validatorShare);
     }
 }

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -153,7 +153,6 @@ describe("NodeOperator", function () {
                 commissionRate: BigNumber.from(0),
                 slashed: BigNumber.from(0),
                 slashedTimestamp: BigNumber.from(0),
-                statusUpdatedTimestamp: BigNumber.from(0),
                 maxDelegateLimit: BigNumber.from(toEth("10"))
             });
 
@@ -169,7 +168,6 @@ describe("NodeOperator", function () {
                 commissionRate: BigNumber.from(0),
                 slashed: BigNumber.from(0),
                 slashedTimestamp: BigNumber.from(0),
-                statusUpdatedTimestamp: BigNumber.from(0),
                 maxDelegateLimit: BigNumber.from(toEth("10"))
             });
         });
@@ -1698,11 +1696,6 @@ async function checkOperator (
     }
     if (no.commissionRate) {
         expect(res.commissionRate, "commissionRate").equal(no.commissionRate);
-    }
-    if (no.statusUpdatedTimestamp) {
-        expect(res.statusUpdatedTimestamp, "statusUpdatedTimestamp").not.equal(
-            no.statusUpdatedTimestamp
-        );
     }
     if (no.maxDelegateLimit) {
         expect(res.maxDelegateLimit, "maxDelegateLimit").equal(no.maxDelegateLimit);

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -403,14 +403,9 @@ describe("NodeOperator", function () {
 
         it("Should fail to join an operator if unstaked", async function () {
             await stakeOperator(1, user1, user1Address, "10", "20");
-            await stakeOperator(2, user2, user2Address, "10", "20");
 
-            // unstake a node operator
-            expect(await nodeOperatorRegistry.connect(user1)["unstake()"].call(this))
-                .to.emit(nodeOperatorRegistry, "UnstakeOperator")
-                .withArgs(1);
-
-            await checkOperator(1, { status: 3 });
+            await stakeManagerMock.unstake(1);
+            await checkOperator(1, { status: 8 });
 
             await expect(
                 nodeOperatorRegistry.connect(user1).joinOperator()

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -658,58 +658,6 @@ describe("NodeOperator", function () {
                     );
                 })
             );
-
-            await expect(
-                nodeOperatorRegistry.exitOperator(ethers.constants.AddressZero)
-            ).revertedWith("Caller is not stMATIC contract");
-        });
-
-        it("Shouldn't allow exiting an operator with invalid address", async () => {
-            const operatorIds = [1, 2, 3];
-            const stakeAmount = "10";
-            const heimdallFees = "20";
-            await Promise.all(
-                operatorIds.map((id, index) => {
-                    const user = accounts[index];
-                    return stakeOperator(
-                        id,
-                        user,
-                        user.address,
-                        stakeAmount,
-                        heimdallFees
-                    );
-                })
-            );
-
-            const no = await nodeOperatorRegistry["getNodeOperator(address)"].call(
-                this,
-                user1Address
-            );
-            await expect(
-                stMATICMock.claimTokens2StMatic(no.validatorShare)
-            ).revertedWith("Invalid status");
-        });
-
-        it("Shouldn't allow exiting an operator if not StMatic", async () => {
-            const operatorIds = [1, 2, 3];
-            const stakeAmount = "10";
-            const heimdallFees = "20";
-            await Promise.all(
-                operatorIds.map((id, index) => {
-                    const user = accounts[index];
-                    return stakeOperator(
-                        id,
-                        user,
-                        user.address,
-                        stakeAmount,
-                        heimdallFees
-                    );
-                })
-            );
-
-            await expect(
-                stMATICMock.claimTokens2StMatic(ethers.constants.AddressZero)
-            ).revertedWith("Operator not found");
         });
 
         it("Success to unjail an operator", async function () {

--- a/test/stmatic-test.ts
+++ b/test/stmatic-test.ts
@@ -310,6 +310,26 @@ describe("Starting to test StMATIC contract", () => {
         expect(balance.eq(1)).to.be.true;
     });
 
+    it("Should withdraw from EJECTED operators", async function () {
+        const amount = ethers.utils.parseEther("100");
+        const amount2Submit = ethers.utils.parseEther("0.05");
+        await mint(testers[0], amount);
+        await addOperator(
+            "BananaOperator",
+            testers[0].address,
+            ethers.utils.randomBytes(64)
+        );
+        await stakeOperator(1, testers[0], "10");
+        await mint(testers[0], amount2Submit);
+        await submit(testers[0], amount2Submit);
+        await nodeOperatorRegistry.connect(testers[0])["unstake()"].call(this);
+
+        await requestWithdraw(testers[0], ethers.utils.parseEther("0.005"));
+
+        const balance = await poLidoNFT.balanceOf(testers[0].address);
+        expect(balance.eq(1)).to.be.true;
+    })
+
     it("Should claim tokens after submitting to contract successfully", async () => {
         const ownedTokens: BigNumber[][] = [];
         const submitAmounts: string[] = [];

--- a/test/stmatic-test.ts
+++ b/test/stmatic-test.ts
@@ -319,15 +319,46 @@ describe("Starting to test StMATIC contract", () => {
             testers[0].address,
             ethers.utils.randomBytes(64)
         );
+
         await stakeOperator(1, testers[0], "10");
         await mint(testers[0], amount2Submit);
         await submit(testers[0], amount2Submit);
-        await nodeOperatorRegistry.connect(testers[0])["unstake()"].call(this);
 
+        await mockStakeManager.unstake(1);
         await requestWithdraw(testers[0], ethers.utils.parseEther("0.005"));
 
         const balance = await poLidoNFT.balanceOf(testers[0].address);
         expect(balance.eq(1)).to.be.true;
+    })
+
+    it("Should withdraw from JAILED operators", async function () {
+        const amount = ethers.utils.parseEther("200");
+        const amount2Submit = ethers.utils.parseEther("150");
+        await mint(testers[0], amount);
+        await addOperator(
+            "BananaOperator",
+            testers[0].address,
+            ethers.utils.randomBytes(64)
+        );
+
+        await stakeOperator(1, testers[0], "200");
+        await mint(testers[0], amount2Submit);
+        await submit(testers[0], amount2Submit);
+
+        await mockStakeManager.slash(1);
+        await requestWithdraw(testers[0], ethers.utils.parseEther("0.005"));
+        const balance = await poLidoNFT.balanceOf(testers[0].address);
+        expect(balance.eq(1)).to.be.true;
+
+        const validatorShareAddress = (
+            await nodeOperatorRegistry["getNodeOperator(uint256)"](1)
+        ).validatorShare;
+
+        const validatorShareBalance = await mockERC20.balanceOf(
+            validatorShareAddress
+        );
+
+        expect(validatorShareBalance.eq(0)).to.be.true;
     })
 
     it("Should claim tokens after submitting to contract successfully", async () => {


### PR DESCRIPTION
This PR contains the fixes for PoLido PR#40 [Security Audit Report Draft](https://hackmd.io/@zi9amULATmi0KrAsnqmmeg/BkHd5v6nK)

**CRITICAL**

1. An unstaked operator may lock funds delegated to it

- We fixed this by removing the call to `nodeOperatorRegistry.exitOperator();` in the `claimTokens2StMatic` function.
- Stopped operator can exit the system by calling migrate function. This one set the status to EXIT [here...](https://github.com/Shard-Labs/PoLido/blob/ca40b0500dc09cddd8793bd5389ce6fec500afaf/contracts/NodeOperatorRegistry.sol#L442)
- The claimFee function set the status to EXIT [here...](https://github.com/Shard-Labs/PoLido/blob/ca40b0500dc09cddd8793bd5389ce6fec500afaf/contracts/NodeOperatorRegistry.sol#L535)

2. A jailed operator may never return the delegated funds

> This was resolved by

- Setting `_allActive` to true in the call to `nodeOperatorRegistry.getOperatorInfos()` to include EJECTED and JAILED operators
- Adding the extra condition `status == NodeOperatorStatus.JAILED` in the `stopOperator()` function. 

3. An ejected operator may never return the delegated funds

> This was resolved by
- Setting `_allActive` to true in the call to `nodeOperatorRegistry.getOperatorInfos()` to include EJECTED and JAILED operators

**MAJOR**
1. A validator that is both jailed and unstaked will have status INACTIVE

> This was resolved by
- Adding the extra condition `poValidator.deactivationEpoch == 0` to ensure that only an active validator can join the protocol.

**COMMENT** 
1. No punishment for disabling delegation
- This was fixed by setting the `_delegation` to true to filter out operators that have disabled delegation. If there are rewards accumulated in the validator that disabled delegation they will be transferred the next time a requestWithdraw or delegation happens.

2. NodeOperator.statusUpdatedTimestamp may be misleading
- This has been removed
3. Most rewards will go to the validators that has most funds delegated to them
- This is currently not the case, all the active operators get the same amount
4. Ambiguous term “active”
- Renamed to `_allWithStake `
5. 3 flags in one function lower readability
- This will be refactored in the v2 phase
6. Flags order does not match filters
- This will be refactored in the v2 phase
7. Complex conditional
- This will be refactored in the v2 phase
8. Unnecessary nested ifs
- This was left the same since it handles the logic for filtering out operators with delegation set to false.
9. Term “operator” is used where “operatorRegistry” should be used
- Renamed to `operatorRegistry` and `isOperatorRegistry ` respectively. 

**Other Notes:** 
- Removed call to exitOperator in the `claimTokens2StMatic` function to ensure that it only claims delegated funds and nothing else.
- Set `_allActive` to true in `requestWithdraw` function to allow users withdraw from ejected or jailed validators
- Remove `exitOperator` since it became redundant
- Ensure that an UNSTAKED operator cannot join the protocol by adding a check in `joinOperator`
- Ensure that only a STOPPED operator can be migrated by changing the status from WAIT to STOPPED
- Set the status of the operator to EXIT after claiming fee