### PR TITLE
Fix issue with distributing rewards to only validators with more stake

### DIFF
--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -959,19 +959,6 @@ contract NodeOperatorRegistry is
                 if (!IValidatorShare(no.validatorShare).delegation()) continue;
             }
 
-            // if true we check if the operator accumulated enough rewards
-            if (_withdrawRewards) {
-                IValidatorShare validatorShare = IValidatorShare(
-                    no.validatorShare
-                );
-                uint256 stMaticReward = validatorShare.getLiquidRewards(
-                    stMATIC
-                );
-                uint256 rewardThreshold = validatorShare.minAmount();
-                if (stMaticReward < rewardThreshold) {
-                    continue;
-                }
-            }
             operatorInfos[index] = Operator.OperatorInfo({
                 operatorId: operatorId,
                 validatorShare: no.validatorShare,

--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -373,7 +373,16 @@ contract StMATIC is
         uint256 operatorInfosLength = operatorInfos.length;
 
         for (uint256 i = 0; i < operatorInfosLength; i++) {
-            IValidatorShare(operatorInfos[i].validatorShare).withdrawRewards();
+            IValidatorShare validatorShare = IValidatorShare(
+                operatorInfos[i].validatorShare
+            );
+            uint256 stMaticReward = validatorShare.getLiquidRewards(
+                address(this)
+            );
+            uint256 rewardThreshold = validatorShare.minAmount();
+            if (stMaticReward > rewardThreshold) {
+                validatorShare.withdrawRewards();
+            }
         }
 
         uint256 totalRewards = (

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -1316,7 +1316,7 @@ describe("NodeOperator", function () {
                 expect(operators.length).eq(1);
             });
 
-            it("success getOperatorInfos validator rewards", async function () {
+            it("success getOperatorInfos with active delegation", async function () {
                 // If the rewards accumulated by a validator are not enough, the operator is ignored.
                 await stakeOperator(1, user1, user1Address, "100", "20");
                 await stakeOperator(2, user2, user2Address, "100", "20");
@@ -1335,9 +1335,9 @@ describe("NodeOperator", function () {
                     ethers.utils.parseEther("10000")
                 );
 
-                const operators = await nodeOperatorRegistry.getOperatorInfos(true, false, false);
+                const operators = await nodeOperatorRegistry.getOperatorInfos(true, true, false);
 
-                expect(operators.length).eq(2);
+                expect(operators.length).eq(3);
                 operators.forEach((op, index: number) => {
                     expect(op.operatorId).eq(index + 1);
                 });


### PR DESCRIPTION
This PR fixes the comment `3` from the audit: `Most rewards will go to the validators that has most funds delegated to them`.
- The solution to this was to remove the filter for checking if the reward that a validator has accumulated is less than the expected reward threshold `(stMaticReward < rewardThreshold)`, from the `getOperatorInfos` function. 