### PR TITLE
Allow both the Operator Owner and DAO stop an operator

### DIFF
--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -220,9 +220,13 @@ contract NodeOperatorRegistry is
     function stopOperator(uint256 _operatorId)
         external
         override
-        userHasRole(DAO_ROLE)
     {
-        (, NodeOperator storage no) = getOperator(_operatorId);
+
+        (, NodeOperator storage no) = getOperator(_operatorId); //this already fails if an oprator does not exist so what? just stick to the node operator check
+        //check that the validatorId is equal to operatorId or that no operator exist
+        require(
+            no.rewardAddress == msg.sender || hasRole(DAO_ROLE, msg.sender), "unauthorized"
+        );
         NodeOperatorStatus status = getOperatorStatus(no);
         checkCondition(
             status <= NodeOperatorStatus.ACTIVE ||

--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -222,8 +222,7 @@ contract NodeOperatorRegistry is
         override
     {
 
-        (, NodeOperator storage no) = getOperator(_operatorId); //this already fails if an oprator does not exist so what? just stick to the node operator check
-        //check that the validatorId is equal to operatorId or that no operator exist
+        (, NodeOperator storage no) = getOperator(_operatorId);
         require(
             no.rewardAddress == msg.sender || hasRole(DAO_ROLE, msg.sender), "unauthorized"
         );

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -328,6 +328,13 @@ describe("NodeOperator", function () {
             await checkOperator(1, { status: 2 });
         });
 
+        it("should stop an operator authorized by the operator owner", async function (){
+            await newOperator(1, user1Address);
+            expect(await nodeOperatorRegistry.connect(user1).stopOperator(1))
+                .to.emit(nodeOperatorRegistry, "StopOperator")
+                .withArgs(1);
+        });
+
         it("Fail stop an operator", async function () {
             // revert invalid operator id
             await expect(nodeOperatorRegistry.stopOperator(10)).revertedWith(
@@ -342,6 +349,10 @@ describe("NodeOperator", function () {
             // revert stop second time
             await expect(nodeOperatorRegistry.stopOperator(1)).to.revertedWith(
                 "Invalid status"
+            );
+
+            await expect(nodeOperatorRegistry.connect(user2).stopOperator(1)).to.revertedWith(
+                "unauthorized"
             );
         });
 


### PR DESCRIPTION
This pr extends the modifier on the `stopOperator` function to check that that operator can be stopped both by the owner and by the DAO.