### PR TITLE
Fixes for Polido audit report 6

### DIFF
--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -27,13 +27,12 @@ contract NodeOperatorRegistry is
         STOPPED,
         UNSTAKED,
         CLAIMED,
-        WAIT,
         EXIT,
         JAILED,
         EJECTED
     }
     /// @notice The node operator struct
-    /// @param status node operator status(INACTIVE, ACTIVE, STOPPED, CLAIMED, UNSTAKED, WAIT, EXIT, JAILED, EJECTED).
+    /// @param status node operator status(INACTIVE, ACTIVE, STOPPED, CLAIMED, UNSTAKED, EXIT, JAILED, EJECTED).
     /// @param name node operator name.
     /// @param rewardAddress Validator public key used for access control and receive rewards.
     /// @param validatorId validator id of this node operator on the polygon stake manager.
@@ -228,7 +227,7 @@ contract NodeOperatorRegistry is
         );
         NodeOperatorStatus status = getOperatorStatus(no);
         checkCondition(
-            status <= NodeOperatorStatus.ACTIVE ||
+            status == NodeOperatorStatus.ACTIVE || status == NodeOperatorStatus.INACTIVE ||
             status == NodeOperatorStatus.JAILED
         , "Invalid status");
 
@@ -566,8 +565,9 @@ contract NodeOperatorRegistry is
         whenNotPaused
     {
         (uint256 operatorId, NodeOperator storage no) = getOperator(0);
+        NodeOperatorStatus status = getOperatorStatus(no);
         checkCondition(
-            getOperatorStatus(no) <= NodeOperatorStatus.ACTIVE,
+            status == NodeOperatorStatus.ACTIVE || status == NodeOperatorStatus.INACTIVE,
             "Invalid status"
         );
         if (no.status == NodeOperatorStatus.ACTIVE) {
@@ -593,8 +593,10 @@ contract NodeOperatorRegistry is
         // uint256 operatorId = getOperatorId(msg.sender);
         // NodeOperator storage no = operators[operatorId];
         (uint256 operatorId, NodeOperator storage no) = getOperator(0);
+        NodeOperatorStatus status = getOperatorStatus(no);
+
         checkCondition(
-            getOperatorStatus(no) <= NodeOperatorStatus.ACTIVE,
+            status == NodeOperatorStatus.ACTIVE || status == NodeOperatorStatus.INACTIVE,
             "Invalid status"
         );
         no.name = _name;
@@ -884,7 +886,6 @@ contract NodeOperatorRegistry is
             uint256 _totalStoppedNodeOperator,
             uint256 _totalUnstakedNodeOperator,
             uint256 _totalClaimedNodeOperator,
-            uint256 _totalWaitNodeOperator,
             uint256 _totalExitNodeOperator,
             uint256 _totalJailedNodeOperator,
             uint256 _totalEjectedNodeOperator
@@ -907,8 +908,6 @@ contract NodeOperatorRegistry is
                 _totalUnstakedNodeOperator++;
             } else if (status == NodeOperatorStatus.CLAIMED) {
                 _totalClaimedNodeOperator++;
-            } else if (status == NodeOperatorStatus.WAIT) {
-                _totalWaitNodeOperator++;
             } else if (status == NodeOperatorStatus.JAILED) {
                 _totalJailedNodeOperator++;
             } else if (status == NodeOperatorStatus.EJECTED) {

--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -698,11 +698,19 @@ contract StMATIC is
         return (balanceInStMatic, totalShares, totalPooledMatic);
     }
 
+
+    function getMinValidatorBalance() external view override returns (uint256) {
+        Operator.OperatorInfo[] memory operatorInfos = nodeOperatorRegistry
+        .getOperatorInfos(false, true);
+
+        return getMinValidatorBalance(operatorInfos);
+    }
+
     /**
      * @dev Function that calculates minimal allowed validator balance (lower bound)
      * @return Minimal validator balance in MATIC
      */
-    function getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) public view override returns (uint256) {
+    function getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) private view returns (uint256) {
         uint256 operatorInfosLength = operatorInfos.length;
         uint256 minValidatorBalance = type(uint256).max;
 

--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -171,7 +171,7 @@ contract StMATIC is
 
         uint256 totalDelegated = getTotalStakeAcrossAllValidators();
 
-        uint256 minValidatorBalance = getMinValidatorBalance(operatorInfos);
+        uint256 minValidatorBalance = _getMinValidatorBalance(operatorInfos);
 
         uint256 allowedAmount2RequestFromValidators = 0;
 
@@ -698,19 +698,19 @@ contract StMATIC is
         return (balanceInStMatic, totalShares, totalPooledMatic);
     }
 
-
-    function getMinValidatorBalance() external view override returns (uint256) {
-        Operator.OperatorInfo[] memory operatorInfos = nodeOperatorRegistry
-        .getOperatorInfos(false, true);
-
-        return getMinValidatorBalance(operatorInfos);
-    }
-
     /**
      * @dev Function that calculates minimal allowed validator balance (lower bound)
      * @return Minimal validator balance in MATIC
      */
-    function getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) private view returns (uint256) {
+    function getMinValidatorBalance() external view override returns (uint256) {
+        Operator.OperatorInfo[] memory operatorInfos = nodeOperatorRegistry
+        .getOperatorInfos(false, true);
+
+        return _getMinValidatorBalance(operatorInfos);
+    }
+
+
+    function _getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) private view returns (uint256) {
         uint256 operatorInfosLength = operatorInfos.length;
         uint256 minValidatorBalance = type(uint256).max;
 

--- a/contracts/StMATIC.sol
+++ b/contracts/StMATIC.sol
@@ -171,7 +171,7 @@ contract StMATIC is
 
         uint256 totalDelegated = getTotalStakeAcrossAllValidators();
 
-        uint256 minValidatorBalance = getMinValidatorBalance();
+        uint256 minValidatorBalance = getMinValidatorBalance(operatorInfos);
 
         uint256 allowedAmount2RequestFromValidators = 0;
 
@@ -380,7 +380,7 @@ contract StMATIC is
                 address(this)
             );
             uint256 rewardThreshold = validatorShare.minAmount();
-            if (stMaticReward > rewardThreshold) {
+            if (stMaticReward >= rewardThreshold) {
                 validatorShare.withdrawRewards();
             }
         }
@@ -702,10 +702,7 @@ contract StMATIC is
      * @dev Function that calculates minimal allowed validator balance (lower bound)
      * @return Minimal validator balance in MATIC
      */
-    function getMinValidatorBalance() public view override returns (uint256) {
-        Operator.OperatorInfo[] memory operatorInfos = nodeOperatorRegistry
-            .getOperatorInfos(false, false);
-
+    function getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) public view override returns (uint256) {
         uint256 operatorInfosLength = operatorInfos.length;
         uint256 minValidatorBalance = type(uint256).max;
 

--- a/contracts/interfaces/INodeOperatorRegistry.sol
+++ b/contracts/interfaces/INodeOperatorRegistry.sol
@@ -148,7 +148,6 @@ interface INodeOperatorRegistry {
             uint256 _totalStoppedNodeOperator,
             uint256 _totalUnstakedNodeOperator,
             uint256 _totalClaimedNodeOperator,
-            uint256 _totalWaitNodeOperator,
             uint256 _totalExitNodeOperator,
             uint256 _totalSlashedNodeOperator,
             uint256 _totalEjectedNodeOperator

--- a/contracts/interfaces/IStMATIC.sol
+++ b/contracts/interfaces/IStMATIC.sol
@@ -72,7 +72,7 @@ interface IStMATIC is IERC20Upgradeable {
 
     function submitHandler() external view returns (bool);
 
-    function getMinValidatorBalance() external view returns (uint256);
+    function getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) external view returns (uint256);
 
     function token2WithdrawRequest(uint256 _requestId)
         external

--- a/contracts/interfaces/IStMATIC.sol
+++ b/contracts/interfaces/IStMATIC.sol
@@ -72,7 +72,7 @@ interface IStMATIC is IERC20Upgradeable {
 
     function submitHandler() external view returns (bool);
 
-    function getMinValidatorBalance(Operator.OperatorInfo[] memory operatorInfos) external view returns (uint256);
+    function getMinValidatorBalance() external view returns (uint256);
 
     function token2WithdrawRequest(uint256 _requestId)
         external

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -137,7 +137,7 @@ describe("NodeOperator", function () {
             const signerPubkey2 = op2.signerPubkey;
 
             // check node operator status
-            await checkStats(2, 2, 0, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(2, 2, 0, 0, 0, 0, 0, 0, 0);
 
             // get all validator proxies from the factory.
             const validatorProxies = await validatorFactory.getValidators();
@@ -253,7 +253,7 @@ describe("NodeOperator", function () {
             expect(no2.validatorProxy).not.equal(ZERO_ADDRESS);
 
             // check global state
-            await checkStats(2, 0, 2, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(2, 0, 2, 0, 0, 0, 0, 0, 0);
         });
 
         it("Fail to stake an operator", async function () {
@@ -303,10 +303,10 @@ describe("NodeOperator", function () {
                 .to.emit(nodeOperatorRegistry, "StopOperator")
                 .withArgs(1);
 
-            await checkOperator(1, { status: 6 });
+            await checkOperator(1, { status: 5 });
 
             // check global state
-            await checkStats(1, 0, 0, 0, 0, 0, 0, 1, 0, 0);
+            await checkStats(1, 0, 0, 0, 0, 0, 1, 0, 0);
 
             await stakeOperator(2, user2, user2Address, "10", "20");
             expect(await nodeOperatorRegistry.stopOperator(2))
@@ -316,7 +316,7 @@ describe("NodeOperator", function () {
             await checkOperator(2, { status: 2 });
 
             // check global state
-            await checkStats(2, 0, 0, 1, 0, 0, 0, 1, 0, 0);
+            await checkStats(2, 0, 0, 1, 0, 0, 1, 0, 0);
         });
 
         it("should stop a JAILED operator", async function () {
@@ -389,7 +389,7 @@ describe("NodeOperator", function () {
 
             no = await nodeOperatorRegistry["getNodeOperator(uint256)"].call(this, 1);
             expect(no.validatorShare).not.equal(ZERO_ADDRESS);
-            await checkStats(1, 0, 1, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(1, 0, 1, 0, 0, 0, 0, 0, 0);
         });
 
         it("Fail join an operator", async function () {
@@ -414,7 +414,7 @@ describe("NodeOperator", function () {
             await stakeOperator(1, user1, user1Address, "10", "20");
 
             await stakeManagerMock.unstake(1);
-            await checkOperator(1, { status: 8 });
+            await checkOperator(1, { status: 7 });
 
             await expect(
                 nodeOperatorRegistry.connect(user1).joinOperator()
@@ -460,7 +460,7 @@ describe("NodeOperator", function () {
                 .to.emit(nodeOperatorRegistry, "RestakeOperator")
                 .withArgs(2, toEth("100"), false);
 
-            await checkStats(2, 0, 2, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(2, 0, 2, 0, 0, 0, 0, 0, 0);
         });
 
         it("Fail restake an operator", async function () {
@@ -501,7 +501,7 @@ describe("NodeOperator", function () {
                 .withArgs(1);
 
             await checkOperator(1, { status: 3 });
-            await checkStats(2, 0, 1, 0, 1, 0, 0, 0, 0, 0);
+            await checkStats(2, 0, 1, 0, 1, 0, 0, 0, 0);
         });
 
         it("Success unstake an operator by the DAO", async function () {
@@ -509,7 +509,7 @@ describe("NodeOperator", function () {
             await stakeOperator(2, user2, user2Address, "10", "20");
 
             await stakeManagerMock.unstake(1);
-            await checkStats(2, 0, 1, 0, 0, 0, 0, 0, 0, 1);
+            await checkStats(2, 0, 1, 0, 0, 0, 0, 0, 1);
 
             // DAO unstake a node operator 1
             expect(await nodeOperatorRegistry["unstake(uint256)"].call(this, 1))
@@ -517,17 +517,17 @@ describe("NodeOperator", function () {
                 .withArgs(1);
 
             await checkOperator(1, { status: 3 });
-            await checkStats(2, 0, 1, 0, 1, 0, 0, 0, 0, 0);
+            await checkStats(2, 0, 1, 0, 1, 0,0, 0, 0);
 
             await stakeManagerMock.unstake(2);
-            await checkStats(2, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+            await checkStats(2, 0, 0, 0, 1, 0,0, 0, 1);
 
             // DAO unstake a node operator 2
             expect(await nodeOperatorRegistry["unstake(uint256)"].call(this, 2))
                 .to.emit(nodeOperatorRegistry, "UnstakeOperator")
                 .withArgs(2);
             await checkOperator(2, { status: 3 });
-            await checkStats(2, 0, 0, 0, 2, 0, 0, 0, 0, 0);
+            await checkStats(2, 0, 0, 0, 2, 0, 0, 0, 0);
         });
 
         it("Fail unstake an operator by the DAO", async function () {
@@ -550,7 +550,7 @@ describe("NodeOperator", function () {
                 .withArgs(1);
 
             await checkOperator(1, { status: 3 });
-            await checkStats(2, 0, 1, 0, 1, 0, 0, 0, 0, 0);
+            await checkStats(2, 0, 1, 0, 1, 0, 0, 0, 0);
         });
 
         it("Successfully unstake when the operator was jailed by the stakeManager", async function () {
@@ -607,8 +607,8 @@ describe("NodeOperator", function () {
                 .to.emit(nodeOperatorRegistry, "MigrateOperator")
                 .withArgs(1);
 
-            await checkOperator(1, { status: 6 });
-            await checkStats(2, 0, 1, 0, 0, 0, 0, 1, 0, 0);
+            await checkOperator(1, { status: 5 });
+            await checkStats(2, 0, 1, 0, 0, 0, 1, 0, 0);
         });
 
         it("Fail migrate NFT to new owner", async function () {
@@ -669,7 +669,7 @@ describe("NodeOperator", function () {
             await nodeOperatorRegistry.stopOperator(2);
             await nodeOperatorRegistry.stopOperator(3);
 
-            await checkStats(3, 0, 0, 3, 0, 0, 0, 0, 0, 0);
+            await checkStats(3, 0, 0, 3, 0, 0, 0, 0, 0);
 
             await stMATICMock.claimTokens2StMatic(no1.validatorShare);
             await stMATICMock.claimTokens2StMatic(no2.validatorShare);
@@ -679,7 +679,7 @@ describe("NodeOperator", function () {
             await nodeOperatorRegistry.connect(user2).migrate();
             await nodeOperatorRegistry.connect(user3).migrate();
 
-            await checkStats(3, 0, 0, 0, 0, 0, 0, 3, 0, 0);
+            await checkStats(3, 0, 0, 0, 0, 0, 3, 0, 0);
         });
 
         it("Shouldn't allow claiming from non exited operator", async () => {
@@ -709,7 +709,7 @@ describe("NodeOperator", function () {
                 .withArgs(1);
 
             await checkOperator(1, { status: 1 });
-            await checkStats(1, 0, 1, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(1, 0, 1, 0, 0, 0, 0, 0, 0);
         });
 
         it("Success to topUpFee", async function () {
@@ -793,7 +793,7 @@ describe("NodeOperator", function () {
 
             await checkOperator(1, { status: 4 });
             await checkOperator(2, { status: 4 });
-            await checkStats(2, 0, 0, 0, 0, 2, 0, 0, 0, 0);
+            await checkStats(2, 0, 0, 0, 0, 2, 0, 0, 0);
         });
 
         it("Fail unstake claim", async function () {
@@ -837,10 +837,10 @@ describe("NodeOperator", function () {
                 .connect(user2)
                 .claimFee(1, 1, ethers.utils.randomBytes(64));
 
-            await checkOperator(1, { status: 6 });
-            await checkOperator(2, { status: 6 });
+            await checkOperator(1, { status: 5 });
+            await checkOperator(2, { status: 5 });
 
-            await checkStats(2, 0, 0, 0, 0, 0, 0, 2, 0, 0);
+            await checkStats(2, 0, 0, 0, 0, 0, 2, 0, 0);
         });
 
         it("Fail claim heimdall fees", async function () {
@@ -1014,7 +1014,7 @@ describe("NodeOperator", function () {
             await stakeOperator(1, user1, user1Address, "10", "20");
             await stakeOperator(2, user2, user2Address, "10", "20");
             await newOperator(3, user3Address);
-            await checkStats(3, 1, 2, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(3, 1, 2, 0, 0, 0, 0, 0, 0);
 
             const no = await nodeOperatorRegistry["getNodeOperator(uint256)"].call(
                 this,
@@ -1023,27 +1023,27 @@ describe("NodeOperator", function () {
             await polygonERC721.mint(no.validatorProxy, 2);
 
             await nodeOperatorRegistry.connect(user1)["unstake()"].call(this);
-            await checkStats(3, 1, 1, 0, 1, 0, 0, 0, 0, 0);
+            await checkStats(3, 1, 1, 0, 1, 0, 0, 0, 0);
 
             await nodeOperatorRegistry.stopOperator(2);
-            await checkStats(3, 1, 0, 1, 1, 0, 0, 0, 0, 0);
+            await checkStats(3, 1, 0, 1, 1, 0, 0, 0, 0);
 
             await nodeOperatorRegistry.stopOperator(3);
-            await checkStats(3, 0, 0, 1, 1, 0, 0, 1, 0, 0);
+            await checkStats(3, 0, 0, 1, 1, 0, 1, 0, 0);
 
             await nodeOperatorRegistry.connect(user1).unstakeClaim();
-            await checkStats(3, 0, 0, 1, 0, 1, 0, 1, 0, 0);
+            await checkStats(3, 0, 0, 1, 0, 1, 1, 0, 0);
 
             await stMATICMock.claimTokens2StMatic(no.validatorShare);
 
             await nodeOperatorRegistry.connect(user2).migrate();
-            await checkStats(3, 0, 0, 0, 0, 1, 0, 2, 0, 0);
+            await checkStats(3, 0, 0, 0, 0, 1, 2, 0, 0);
 
             await nodeOperatorRegistry
                 .connect(user1)
                 .claimFee(1, 1, ethers.utils.randomBytes(64));
 
-            await checkStats(3, 0, 0, 0, 0, 0, 0, 3, 0, 0);
+            await checkStats(3, 0, 0, 0, 0, 0, 3, 0, 0);
 
             expect(await nodeOperatorRegistry.removeOperator(1))
                 .to.emit(nodeOperatorRegistry, "RemoveOperator")
@@ -1055,7 +1055,7 @@ describe("NodeOperator", function () {
                 .to.emit(nodeOperatorRegistry, "RemoveOperator")
                 .withArgs(3);
 
-            await checkStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            await checkStats(0, 0, 0, 0, 0, 0, 0, 0, 0);
 
             expect(
                 (await validatorFactory.getValidators()).length,
@@ -1255,7 +1255,7 @@ describe("NodeOperator", function () {
                 // slash op 1
                 await stakeManagerMock.slash(1);
                 // op 1 is not included
-                let operators = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                let operators = await nodeOperatorRegistry.getOperatorInfos(false, false);
                 expect(operators.length).eq(2);
                 // op 1 is included
                 operators = await nodeOperatorRegistry.getOperatorInfos(false, true);
@@ -1264,10 +1264,10 @@ describe("NodeOperator", function () {
                 // unstake op 2
                 await stakeManagerMock.unstake(2);
                 // op 2 is not included
-                operators = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                operators = await nodeOperatorRegistry.getOperatorInfos(false, false);
                 expect(operators.length).eq(1);
                 // include op2 + op1 (EJECTED, JAILED)
-                operators = await nodeOperatorRegistry.getOperatorInfos( false, true);
+                operators = await nodeOperatorRegistry.getOperatorInfos(false, true);
                 expect(operators.length).eq(3);
 
                 // set operator 3 delegation to false
@@ -1291,7 +1291,7 @@ describe("NodeOperator", function () {
                 await stakeOperator(2, user2, user2Address, "100", "20");
                 await stakeOperator(3, user3, user3Address, "100", "20");
 
-                let operators = await nodeOperatorRegistry.getOperatorInfos( true, false);
+                let operators = await nodeOperatorRegistry.getOperatorInfos(true, false);
                 expect(operators.length).eq(3);
 
                 // set operator 3 delegation to false
@@ -1319,15 +1319,15 @@ describe("NodeOperator", function () {
                 await stakeManagerMock.unstake(3);
                 await checkOperator(1, { status: 1 }); // ACTIVE
                 await checkOperator(2, { status: 1 }); // ACTIVE
-                await checkOperator(3, { status: 8 }); // EJECTED
-                let operators = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                await checkOperator(3, { status: 7 }); // EJECTED
+                let operators = await nodeOperatorRegistry.getOperatorInfos(false, false);
 
                 expect(operators.length).eq(2);
                 operators.forEach((op, index: number) => {
                     expect(op.operatorId).eq(index + 1);
                 });
 
-                operators = await nodeOperatorRegistry.getOperatorInfos( false, true);
+                operators = await nodeOperatorRegistry.getOperatorInfos(false, true);
                 expect(operators.length).eq(3);
 
                 await stakeManagerMock.slash(2);
@@ -1357,7 +1357,7 @@ describe("NodeOperator", function () {
                     ethers.utils.parseEther("10000")
                 );
 
-                const operators = await nodeOperatorRegistry.getOperatorInfos( true, false);
+                const operators = await nodeOperatorRegistry.getOperatorInfos(true, false);
 
                 expect(operators.length).eq(3);
                 operators.forEach((op, index: number) => {
@@ -1373,7 +1373,7 @@ describe("NodeOperator", function () {
                 await stakeOperator(3, user3, user3Address, "100", "20");
 
                 await stakeManagerMock.unstake(3);
-                const operators = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                const operators = await nodeOperatorRegistry.getOperatorInfos(false, false);
 
                 expect(operators.length).eq(2);
                 operators.forEach((op, index) => {
@@ -1398,7 +1398,7 @@ describe("NodeOperator", function () {
                 await stakeManagerMock.slash(1);
                 await stakeManagerMock.slash(3);
 
-                operators = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                operators = await nodeOperatorRegistry.getOperatorInfos(false, false);
 
                 expect(operators.length, "operators.length").eq(1);
                 await checkOperator(2, {
@@ -1414,7 +1414,7 @@ describe("NodeOperator", function () {
                 await newOperator(3, user3Address);
 
                 // get all active operators
-                let res = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                let res = await nodeOperatorRegistry.getOperatorInfos(false, false);
                 expect(res.length, "get all active operators").eq(2);
                 for (let i = 0; i < res.length; i++) {
                     expect(res[i].operatorId, "operatorId").eq(i + 1);
@@ -1423,7 +1423,7 @@ describe("NodeOperator", function () {
                 // unstake the 2rd operator
                 await nodeOperatorRegistry.connect(user2)["unstake()"].call(this);
 
-                res = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                res = await nodeOperatorRegistry.getOperatorInfos(false, false);
                 expect(res.length, "unstake the 2rd operator").eq(1);
                 for (let i = 0; i < res.length; i++) {
                     expect(res[i].operatorId, "operatorId").eq(i + 1);
@@ -1432,16 +1432,16 @@ describe("NodeOperator", function () {
                 // stop the 1st operator
                 await nodeOperatorRegistry.stopOperator(1);
 
-                res = await nodeOperatorRegistry.getOperatorInfos( false, false);
+                res = await nodeOperatorRegistry.getOperatorInfos(false, false);
                 expect(res.length, "stop the 1st operator").eq(0);
             });
 
-            it("should check validator status is EJECTED when slashed or unstaked", async function (){
+            it("should check validator status is EJECTED when slashed or unstaked", async function () {
                 await stakeOperator(1, user1, user1Address, "100", "20");
                 await stakeManagerMock.slash(1);
-                await stakeManagerMock.unstake(1)
-                await checkOperator(1, { status: 8 });
-            })
+                await stakeManagerMock.unstake(1);
+                await checkOperator(1, { status: 7 });
+            });
         });
     });
 
@@ -1643,7 +1643,6 @@ async function checkStats (
     totalStoppedNodeOperator: number,
     totalUnstakedNodeOperator: number,
     totalClaimedNodeOperator: number,
-    totalWaitNodeOperator: number,
     totalExitNodeOperator: number,
     totalSlashedNodeOperator: number,
     totalEjectedNodeOperator: number
@@ -1665,16 +1664,13 @@ async function checkStats (
     expect(stats[5].toNumber(), "totalClaimedNodeOperator").equal(
         totalClaimedNodeOperator
     );
-    expect(stats[6].toNumber(), "totalWaitNodeOperator").equal(
-        totalWaitNodeOperator
-    );
-    expect(stats[7].toNumber(), "totalExitNodeOperator").equal(
+    expect(stats[6].toNumber(), "totalExitNodeOperator").equal(
         totalExitNodeOperator
     );
-    expect(stats[8].toNumber(), "totalSlashedNodeOperator").equal(
+    expect(stats[7].toNumber(), "totalSlashedNodeOperator").equal(
         totalSlashedNodeOperator
     );
-    expect(stats[9].toNumber(), "totalSlashedNodeOperator").equal(
+    expect(stats[8].toNumber(), "totalSlashedNodeOperator").equal(
         totalEjectedNodeOperator
     );
 }

--- a/test/stmatic-test.ts
+++ b/test/stmatic-test.ts
@@ -324,13 +324,15 @@ describe("Starting to test StMATIC contract", () => {
         await stakeOperator(1, testers[0], "10");
         await mint(testers[0], amount2Submit);
         await submit(testers[0], amount2Submit);
+        await stMATIC.delegate();
 
         await mockStakeManager.unstake(1);
         await requestWithdraw(testers[0], ethers.utils.parseEther("0.005"));
 
-        const balance = await poLidoNFT.balanceOf(testers[0].address);
-        expect(balance.eq(1)).to.be.true;
-    })
+        const tokens = await poLidoNFT.getOwnedTokens(testers[0].address);
+        const RequestWithdraw = await stMATIC.token2WithdrawRequest(tokens[0]);
+        expect(RequestWithdraw.validatorAddress).to.not.equal(ethers.constants.AddressZero);
+    });
 
     it("Should withdraw from JAILED operators", async function () {
         const amount = ethers.utils.parseEther("200");
@@ -345,22 +347,15 @@ describe("Starting to test StMATIC contract", () => {
         await stakeOperator(1, testers[0], "200");
         await mint(testers[0], amount2Submit);
         await submit(testers[0], amount2Submit);
+        await stMATIC.delegate();
 
         await mockStakeManager.slash(1);
         await requestWithdraw(testers[0], ethers.utils.parseEther("0.005"));
-        const balance = await poLidoNFT.balanceOf(testers[0].address);
-        expect(balance.eq(1)).to.be.true;
 
-        const validatorShareAddress = (
-            await nodeOperatorRegistry["getNodeOperator(uint256)"](1)
-        ).validatorShare;
-
-        const validatorShareBalance = await mockERC20.balanceOf(
-            validatorShareAddress
-        );
-
-        expect(validatorShareBalance.eq(0)).to.be.true;
-    })
+        const tokens = await poLidoNFT.getOwnedTokens(testers[0].address);
+        const RequestWithdraw = await stMATIC.token2WithdrawRequest(tokens[0]);
+        expect(RequestWithdraw.validatorAddress).to.not.equal(ethers.constants.AddressZero);
+    });
 
     it("Should claim tokens after submitting to contract successfully", async () => {
         const ownedTokens: BigNumber[][] = [];

--- a/test/stmatic-test.ts
+++ b/test/stmatic-test.ts
@@ -513,14 +513,13 @@ describe("Starting to test StMATIC contract", () => {
         await submit(testers[0], submitAmount);
         await stMATIC.delegate();
 
-        const nodeOperators = await nodeOperatorRegistry.getOperatorInfos(false, false);
-        const minValidatorBalanceBefore = await stMATIC.getMinValidatorBalance(nodeOperators);
+        const minValidatorBalanceBefore = await stMATIC.getMinValidatorBalance();
 
         await mint(testers[0], submitAmount.mul(2));
         await submit(testers[0], submitAmount);
         await stMATIC.delegate();
 
-        const minValidatorBalanceAfter = await stMATIC.getMinValidatorBalance(nodeOperators);
+        const minValidatorBalanceAfter = await stMATIC.getMinValidatorBalance();
 
         expect(!minValidatorBalanceBefore.eq(minValidatorBalanceAfter)).to.be.true;
     });
@@ -558,9 +557,8 @@ describe("Starting to test StMATIC contract", () => {
 
         await stMATIC.delegate();
 
-        const nodeOperators = await nodeOperatorRegistry.getOperatorInfos(false, false);
         const maxWithdrawPerDelegator = (await stMATIC.getTotalPooledMatic())
-            .sub(await stMATIC.getMinValidatorBalance(nodeOperators))
+            .sub(await stMATIC.getMinValidatorBalance())
             .div(delegatorsAmount);
 
         for (let i = 0; i < delegatorsAmount; i++) {

--- a/test/stmatic-test.ts
+++ b/test/stmatic-test.ts
@@ -513,13 +513,14 @@ describe("Starting to test StMATIC contract", () => {
         await submit(testers[0], submitAmount);
         await stMATIC.delegate();
 
-        const minValidatorBalanceBefore = await stMATIC.getMinValidatorBalance();
+        const nodeOperators = await nodeOperatorRegistry.getOperatorInfos(false, false);
+        const minValidatorBalanceBefore = await stMATIC.getMinValidatorBalance(nodeOperators);
 
         await mint(testers[0], submitAmount.mul(2));
         await submit(testers[0], submitAmount);
         await stMATIC.delegate();
 
-        const minValidatorBalanceAfter = await stMATIC.getMinValidatorBalance();
+        const minValidatorBalanceAfter = await stMATIC.getMinValidatorBalance(nodeOperators);
 
         expect(!minValidatorBalanceBefore.eq(minValidatorBalanceAfter)).to.be.true;
     });
@@ -557,8 +558,9 @@ describe("Starting to test StMATIC contract", () => {
 
         await stMATIC.delegate();
 
+        const nodeOperators = await nodeOperatorRegistry.getOperatorInfos(false, false);
         const maxWithdrawPerDelegator = (await stMATIC.getTotalPooledMatic())
-            .sub(await stMATIC.getMinValidatorBalance())
+            .sub(await stMATIC.getMinValidatorBalance(nodeOperators))
             .div(delegatorsAmount);
 
         for (let i = 0; i < delegatorsAmount; i++) {


### PR DESCRIPTION
This PR contains the fixes for the Polido Audit [report 6](https://hackmd.io/@oxorio/S1gYRNdy9):

# WARNING

1. Impossible to withdraw if there are no active validators

- Fixed by changing the function signature of the `getMinValidatorBalance` by adding an `operatorInfos` parameter. The operator info from `getOperatorInfos(false, true)` was then passed into it. 

2. minValidatorBalance may be greater than expected

- Fixed by changing the function signature of the `getMinValidatorBalance` by adding an `operatorInfos` parameter. The operator info from `getOperatorInfos(false, true)` was then passed into it. 

# INFO/COMMENT

1. NodeOperator WAIT status is not used

- WAIT status was removed and tests fixed

2. unstake(uint256 _operatorId) almost duplicate stopOperator logic

- Will be resolved in v2

3. A jailed or ejected operator will still keep minValidatorBalance of funds

- Will be resolved in v2

4. withdrawRewards will skip a validator when rewards == rewardThreshold

- recommended fix was implemented

5. Usage of comparison when checking NodeOperatorStatus enum values

- recommended fix was implemented