### PR TITLE
Replace operator id with nodeOperatorCounter

### DIFF
--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -74,6 +74,9 @@ contract NodeOperatorRegistry is
     /// @notice stMATIC address.
     address private stMATIC;
 
+    /// @notice keeps track of total number of operators
+    uint256 nodeOperatorCounter;
+
     /// @notice min amount allowed to stake per validator.
     uint256 public minAmountStake;
 
@@ -193,10 +196,10 @@ contract NodeOperatorRegistry is
         userHasRole(DAO_ROLE)
         checkIfRewardAddressIsUsed(_rewardAddress)
     {
-        uint256 operatorId = totalNodeOperators + 1;
+        nodeOperatorCounter++;
         address validatorProxy = IValidatorFactory(validatorFactory).create();
 
-        operators[operatorId] = NodeOperator({
+        operators[nodeOperatorCounter] = NodeOperator({
             status: NodeOperatorStatus.INACTIVE,
             name: _name,
             rewardAddress: _rewardAddress,
@@ -207,11 +210,11 @@ contract NodeOperatorRegistry is
             commissionRate: commissionRate,
             maxDelegateLimit: defaultMaxDelegateLimit
         });
-        operatorIds.push(operatorId);
+        operatorIds.push(nodeOperatorCounter);
         totalNodeOperators++;
-        operatorOwners[_rewardAddress] = operatorId;
+        operatorOwners[_rewardAddress] = nodeOperatorCounter;
 
-        emit AddOperator(operatorId);
+        emit AddOperator(nodeOperatorCounter);
     }
 
     /// @notice Allows to stop an operator from the system.

--- a/test/NodeOperator.test.ts
+++ b/test/NodeOperator.test.ts
@@ -1247,6 +1247,22 @@ describe("NodeOperator", function () {
         });
 
         describe("operator infos", async function () {
+            it("should ensure that no operator id is overridden", async function () {
+                await newOperator(1, user1Address);
+                await newOperator(2, user2Address);
+
+                await nodeOperatorRegistry.stopOperator(1);
+
+                await nodeOperatorRegistry.removeOperator(1);
+                await newOperator(3, user3Address);
+
+                const op2 = await nodeOperatorRegistry["getNodeOperator(uint256)"].call(this, 2);
+                expect(op2.rewardAddress).to.equal(user2Address);
+                const op3 = await nodeOperatorRegistry["getNodeOperator(uint256)"].call(this, 3);
+                expect(op3.rewardAddress).to.equal(user3Address);
+                await checkStats(2, 2, 0, 0, 0, 0, 0, 0, 0);
+            });
+
             it("success getOperatorInfos all cases", async function () {
                 await stakeOperator(1, user1, user1Address, "100", "20");
                 await stakeOperator(2, user2, user2Address, "100", "20");


### PR DESCRIPTION
This pr adds the fix that replaces the `opratorId` with `nodeOperatorCounter` to avoid reassigning an operator Id to a new operator if an older operator was removed.