### PR TITLE
Disable withdraw total delegation when migrate slots

### DIFF
--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -237,7 +237,7 @@ contract NodeOperatorRegistry is
         if (status == NodeOperatorStatus.INACTIVE) {
             no.status = NodeOperatorStatus.EXIT;
         } else {
-            IStMATIC(stMATIC).withdrawTotalDelegated(no.validatorShare);
+            // IStMATIC(stMATIC).withdrawTotalDelegated(no.validatorShare);
             no.status = NodeOperatorStatus.STOPPED;
         }
         emit StopOperator(_operatorId);


### PR DESCRIPTION
## Migrate To V2

This PR is mandatory before migrating to V2. The main purpose is to migrate validator slots to the reward addresses without unstake the delegated amount from the validator.

## Steps

1. Disable withdrawal total delegation when migrating slots.
2. Upgrade the contract.
3. validators call stopOperator.
4. validators call migrate.
