### PR TITLE
fix typo in PoLidoNFT.test.ts

### DIFF
--- a/test/LidoNFT.test.ts
+++ b/test/LidoNFT.test.ts
@@ -57,7 +57,7 @@ describe("PoLidoNFT Tests", () => {
             await poLidoNFT.mint(user2.address);
             const tokenIndex = await poLidoNFT.tokenIdIndex();
             await expect(poLidoNFT.connect(user1).approve(user1.address, tokenIndex))
-                .revertedWith("ERC721: approve caller is not owner nor approved for all");
+                .revertedWith("ERC721: approve caller is not token owner nor approved for all");
         });
     });
 


### PR DESCRIPTION
there are minor typo in a expected error message.


<img width="979" alt="image" src="https://user-images.githubusercontent.com/49754494/189458751-d5b2f600-1674-4b35-a910-28117c16da38.png">
