### PR TITLE
fix: remove condition from withdrawReward

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1965,6 +1965,272 @@
           }
         }
       }
+    },
+    "c7ce217379d789a21342b3fe7e9cd73345386e9c578f8e0f997c8db20f2ef513": {
+      "address": "0xbb555f081BC76dB844018173fb0830c724407415",
+      "txHash": "0x3f71fe8f32a109cc9737f8e5cf61542f5e4b605c0be4dca54396d103ba4e996d",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:97"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:36"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)43_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:64"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:232"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "_status",
+            "type": "t_uint256",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:68"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "version",
+            "type": "t_string_storage",
+            "src": "contracts/NodeOperatorRegistry.sol:64"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "totalNodeOperators",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:66"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "validatorFactory",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:69"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "stakeManager",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:71"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "polygonERC20",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:73"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "stMATIC",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:75"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "nodeOperatorCounter",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:78"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "minAmountStake",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:81"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "minHeimdallFees",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:84"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "commissionRate",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:87"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "allowsRestake",
+            "type": "t_bool",
+            "src": "contracts/NodeOperatorRegistry.sol:90"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "defaultMaxDelegateLimit",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:93"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "operatorIds",
+            "type": "t_array(t_uint256)dyn_storage",
+            "src": "contracts/NodeOperatorRegistry.sol:96"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "operatorOwners",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/NodeOperatorRegistry.sol:100"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "operators",
+            "type": "t_mapping(t_uint256,t_struct(NodeOperator)4862_storage)",
+            "src": "contracts/NodeOperatorRegistry.sol:104"
+          }
+        ],
+        "types": {
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_uint256,t_struct(NodeOperator)4862_storage)": {
+            "label": "mapping(uint256 => struct NodeOperatorRegistry.NodeOperator)"
+          },
+          "t_struct(NodeOperator)4862_storage": {
+            "label": "struct NodeOperatorRegistry.NodeOperator",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(NodeOperatorStatus)4842"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "rewardAddress",
+                "type": "t_address"
+              },
+              {
+                "label": "signerPubkey",
+                "type": "t_bytes_storage"
+              },
+              {
+                "label": "validatorShare",
+                "type": "t_address"
+              },
+              {
+                "label": "validatorProxy",
+                "type": "t_address"
+              },
+              {
+                "label": "validatorId",
+                "type": "t_uint256"
+              },
+              {
+                "label": "commissionRate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "maxDelegateLimit",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_enum(NodeOperatorStatus)4842": {
+            "label": "enum NodeOperatorRegistry.NodeOperatorStatus",
+            "members": [
+              "INACTIVE",
+              "ACTIVE",
+              "STOPPED",
+              "UNSTAKED",
+              "CLAIMED",
+              "EXIT",
+              "JAILED",
+              "EJECTED"
+            ]
+          },
+          "t_bytes_storage": {
+            "label": "bytes"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)43_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)43_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -2118,6 +2118,272 @@
           {
             "contract": "NodeOperatorRegistry",
             "label": "operators",
+            "type": "t_mapping(t_uint256,t_struct(NodeOperator)2190_storage)",
+            "src": "contracts/NodeOperatorRegistry.sol:104"
+          }
+        ],
+        "types": {
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_uint256,t_struct(NodeOperator)2190_storage)": {
+            "label": "mapping(uint256 => struct NodeOperatorRegistry.NodeOperator)"
+          },
+          "t_struct(NodeOperator)2190_storage": {
+            "label": "struct NodeOperatorRegistry.NodeOperator",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(NodeOperatorStatus)2170"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "rewardAddress",
+                "type": "t_address"
+              },
+              {
+                "label": "signerPubkey",
+                "type": "t_bytes_storage"
+              },
+              {
+                "label": "validatorShare",
+                "type": "t_address"
+              },
+              {
+                "label": "validatorProxy",
+                "type": "t_address"
+              },
+              {
+                "label": "validatorId",
+                "type": "t_uint256"
+              },
+              {
+                "label": "commissionRate",
+                "type": "t_uint256"
+              },
+              {
+                "label": "maxDelegateLimit",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_enum(NodeOperatorStatus)2170": {
+            "label": "enum NodeOperatorRegistry.NodeOperatorStatus",
+            "members": [
+              "INACTIVE",
+              "ACTIVE",
+              "STOPPED",
+              "UNSTAKED",
+              "CLAIMED",
+              "EXIT",
+              "JAILED",
+              "EJECTED"
+            ]
+          },
+          "t_bytes_storage": {
+            "label": "bytes"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)43_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)43_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          }
+        }
+      }
+    },
+    "b5816c19e001d3004f915c00eb3da4f50485bebd569451f3fa1784205a52140f": {
+      "address": "0x1F09e21c1C21054429970a22551937Baffb5Ea07",
+      "txHash": "0xe3a8db8f9b76161c1303d12605ff9208347af92a843d0803d82180dc32cc7776",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:97"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:36"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "_roles",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)43_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:64"
+          },
+          {
+            "contract": "AccessControlUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:232"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "_status",
+            "type": "t_uint256",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:68"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "version",
+            "type": "t_string_storage",
+            "src": "contracts/NodeOperatorRegistry.sol:64"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "totalNodeOperators",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:66"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "validatorFactory",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:69"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "stakeManager",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:71"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "polygonERC20",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:73"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "stMATIC",
+            "type": "t_address",
+            "src": "contracts/NodeOperatorRegistry.sol:75"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "nodeOperatorCounter",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:78"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "minAmountStake",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:81"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "minHeimdallFees",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:84"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "commissionRate",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:87"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "allowsRestake",
+            "type": "t_bool",
+            "src": "contracts/NodeOperatorRegistry.sol:90"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "defaultMaxDelegateLimit",
+            "type": "t_uint256",
+            "src": "contracts/NodeOperatorRegistry.sol:93"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "operatorIds",
+            "type": "t_array(t_uint256)dyn_storage",
+            "src": "contracts/NodeOperatorRegistry.sol:96"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "operatorOwners",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/NodeOperatorRegistry.sol:100"
+          },
+          {
+            "contract": "NodeOperatorRegistry",
+            "label": "operators",
             "type": "t_mapping(t_uint256,t_struct(NodeOperator)4862_storage)",
             "src": "contracts/NodeOperatorRegistry.sol:104"
           }

--- a/contracts/NodeOperatorRegistry.sol
+++ b/contracts/NodeOperatorRegistry.sol
@@ -545,10 +545,7 @@ contract NodeOperatorRegistry is
     /// @notice Allows the operator's owner to withdraw rewards.
     function withdrawRewards() external override whenNotPaused {
         (uint256 operatorId, NodeOperator storage no) = getOperator(0);
-        checkCondition(
-            getOperatorStatus(no) == NodeOperatorStatus.ACTIVE,
-            "Invalid status"
-        );
+
         address rewardAddress = no.rewardAddress;
         uint256 rewards = IValidator(no.validatorProxy).withdrawRewards(
             no.validatorId,


### PR DESCRIPTION
# Summary
The PR fix this [issue](https://etherscan.io/tx/0x7bdfb81673d1451b3bf18f9276a9c4ce0d0762a710aa530c78094c1e9820c9c0)
When a validator is not in an active state he can not withdraw rewards.
- Remove the node operator status from the function `withdrawRewards`
#Upgrade Flow
- Doc to upgrade the contract: [step 8](https://www.notion.so/shardlabs/Migration-Cookbook-Lido-On-Polygon-V2-referral-f912d44a311d443a94f84a76fc7a33a4)